### PR TITLE
Add support for commands with no parameters

### DIFF
--- a/Mirage.Mvvm/ViewModel/CommandBase.cs
+++ b/Mirage.Mvvm/ViewModel/CommandBase.cs
@@ -31,18 +31,25 @@ namespace Mirage.ViewModel.Commands
         /// <returns>True if the command can be executed with the given parameter; false otherwise</returns>
         public bool CanExecute(object parameter)
         {
-            if (parameter == null)
-                return false;
-
-            if (!(parameter is T))
-                return false;
-
-            if (IsExecuting)
+            if (typeof(T) == typeof(VoidType))
             {
-                return false;
+                return CanExecute(VoidType.Empty);
             }
+            else
+            {
+                if (parameter == null)
+                    return false;
 
-            return CanExecute((T)parameter);
+                if (!(parameter is T))
+                    return false;
+
+                if (IsExecuting)
+                {
+                    return false;
+                }
+
+                return CanExecute((T)parameter);
+            }
         }
         /// <summary>
         /// Execute the command with the given object as parameter

--- a/Mirage.Mvvm/ViewModel/IAsyncCommand.cs
+++ b/Mirage.Mvvm/ViewModel/IAsyncCommand.cs
@@ -20,4 +20,9 @@ namespace Mirage.ViewModel.Commands
     {
 
     }
+
+    public interface IAsyncCommand : IAsyncCommand<VoidType>
+    {
+
+    }
 }


### PR DESCRIPTION
Commands with no parameters still require voidtype to be passed. This bypasses that requirement.